### PR TITLE
Allow us to get a version > 28

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net"
 	"net/http"
 	"net/url"
@@ -550,7 +551,7 @@ func checkSchemaVersionID(versionID interface{}) error {
 	}
 
 	if verInt, ok := versionID.(int); ok {
-		if verInt <= 0 || verInt > 2^31-1 { // it's the max of int32, math.MaxInt32 already but do that check.
+		if verInt <= 0 || verInt > math.MaxInt32 {
 			return fmt.Errorf("client: %v integer is not a valid value for the versionID input parameter [ versionID > 0 && versionID <= 2^31-1]", versionID)
 		}
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -120,3 +120,10 @@ func TestIsRegisteredWrongHeader(t *testing.T) {
 	mustEqual(t, isreg, false)
 	mustEqual(t, err.Error(), "client: (: ) failed with error code 50103 wrong content type")
 }
+
+func TestVersionCheck(t *testing.T) {
+	err := checkSchemaVersionID(29)
+	if err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
The previous check had a bug that meant that it would throw an error if
a version is greater than 28. In the comment, they mention they could
use `math.MaxInt32`, so not sure why they didn't.

Not even sure why they do this check, but anyway this fixes it!